### PR TITLE
Fix "New Zealand" broken accent in the french translation

### DIFF
--- a/countries.yaml
+++ b/countries.yaml
@@ -4158,7 +4158,7 @@ NZ:
   names: 
     - "New Zealand"
     - Neuseeland
-    - "Nouvelle ZÃ©lande"
+    - "Nouvelle Zélande"
     - "Nueva Zelanda"
   national_destination_code_lengths: 
     - 1


### PR DESCRIPTION
This fixes the encoding issue on the New Zealand french translation.
This was the only issue on french translations.